### PR TITLE
Close file descriptors after cleaning up, to prevent stability issues

### DIFF
--- a/Undecimus/multi_path_sploit.c
+++ b/Undecimus/multi_path_sploit.c
@@ -887,11 +887,6 @@ void mptcp_go() {
   wk64(pipe + 0x08, 0);
   wk64(pipe + 0x10, 0);
     
- for (int i = 0; i < next_read_fd; i++) {
-    close(write_fds[i]);
-    close(read_fds[i]);
-  }
-  
   // do the same for the other end:
   ofiles_offset = ofiles_base + ((replacer_pipe+1) * 8);
   
@@ -908,6 +903,12 @@ void mptcp_go() {
   wk64(pipe + 0x00, 0);
   wk64(pipe + 0x08, 0);
   wk64(pipe + 0x10, 0);
+  
+  for (int i = 0; i < next_read_fd; i++) {
+    close(write_fds[i]);
+    close(read_fds[i]);
+  }
+  
   
   // that should have cleared everything up!
   printf("done!\n");


### PR DESCRIPTION
If we close fds first, clean up code will fail because it is associated with them. Before you pulled RC7 I saw you were talking about stability issues caused by closing fds. This shall fix it.