### PR TITLE
Properly check for mptcp permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ UI by [@DennisBednarz](https://twitter.com/DennisBednarz) & [Samg_is_a_Ninja](ht
 * RC8: Fix the snapshot errors, add a warning for the iOS 11.0-11.1.2 and 11.4 Beta 1 - 3 devices and clean up the code:  [Download (IPA)](https://github.com/pwn20wndstuff/Undecimus/raw/master/Resources/Undecimus-RC8.ipa)
 * RC9: Fix the "Device will be restarted" loop, add even more detailed error messages and add an option to increase the memory limit to improve the stability and add compatibility layer to work correctly with some tweaks that were specifically made for the other jailbreaks:  [Download (IPA)](https://github.com/pwn20wndstuff/Undecimus/raw/master/Resources/Undecimus.ipa)
 * V1: Fix the RootFS Restore for all supported versions, fix the snapshot related issues, make the settings tab match with the rest of the UI, more minor fixes and get this out of beta (Known issues: Some Beta firmwares are still broken):  [Download (IPA)](https://github.com/pwn20wndstuff/Undecimus/raw/master/Resources/Undecimus-V1.ipa)
-* V1.0.1: Attempt to fix the unstable RootFS Restore process, ldrestart errors and others (Known issues: Some Beta firmwares are still broken):  [Download (IPA)](https://github.com/pwn20wndstuff/Undecimus/raw/master/Resources/Undecimus.ipa)
+* V1.0.1: DISABLE THE ROOTFS RESTORE ON IOS 11.0 - 11.1.2 AND ATTEMPT TO FIX SOME OTHERS (Known issues: Some Beta firmwares are still broken):  [Download (IPA)](https://github.com/pwn20wndstuff/Undecimus/raw/master/Resources/Undecimus.ipa)
 
 ## Special Thanks
 * [@i41nbeer](https://twitter.com/i41nbeer) for triple_fetch, async_wake, empty_list & multi_path

--- a/Undecimus/SettingsTableViewController.m
+++ b/Undecimus/SettingsTableViewController.m
@@ -8,6 +8,7 @@
 
 #include <sys/utsname.h>
 #include <sys/sysctl.h>
+#include <sys/socket.h>
 #import "SettingsTableViewController.h"
 #include "common.h"
 #include "ViewController.h"
@@ -267,7 +268,7 @@ double uptime(){
     [self.KernelExploitSegmentedControl setSelectedSegmentIndex:[[NSUserDefaults standardUserDefaults] integerForKey:@K_EXPLOIT]];
     [self.DisableAutoUpdatesSwitch setOn:[[NSUserDefaults standardUserDefaults] boolForKey:@K_DISABLE_AUTO_UPDATES]];
     [self.DisableAppRevokesSwitch setOn:[[NSUserDefaults standardUserDefaults] boolForKey:@K_DISABLE_APP_REVOKES]];
-    [self.KernelExploitSegmentedControl setEnabled:[[self _provisioningProfileAtPath:[[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"]][@"Entitlements"][@"com.apple.developer.networking.multipath"] boolValue] forSegmentAtIndex:1];
+    [self.KernelExploitSegmentedControl setEnabled:(socket(39, 1, 0) >= 0) forSegmentAtIndex:1];
     [self.KernelExploitSegmentedControl setEnabled:([[[NSMutableDictionary alloc] initWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"][@"ProductBuildVersion"] rangeOfString:@"15A"].location != NSNotFound || [[[NSMutableDictionary alloc] initWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"][@"ProductBuildVersion"] rangeOfString:@"15B"].location != NSNotFound) forSegmentAtIndex:2];
     [self.OpenCydiaButton setEnabled:[[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"cydia://"]]];
     [self.ExpiryLabel setPlaceholder:[NSString stringWithFormat:@"%d Days", (int)[[self _provisioningProfileAtPath:[[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"]][@"ExpirationDate"] timeIntervalSinceDate:[NSDate date]] / 86400]];

--- a/Undecimus/SettingsTableViewController.m
+++ b/Undecimus/SettingsTableViewController.m
@@ -276,7 +276,7 @@ double uptime(){
     [self.RestoreRootFSSwitch setOn:[[NSUserDefaults standardUserDefaults] boolForKey:@K_RESTORE_ROOTFS]];
     [self.UptimeLabel setPlaceholder:[NSString stringWithFormat:@"%d Days", (int)uptime() / 86400]];
     [self.IncreaseMemoryLimitSwitch setOn:[[NSUserDefaults standardUserDefaults] boolForKey:@K_INCREASE_MEMORY_LIMIT]];
-    [self.RestoreRootFSSwitch setEnabled:(kCFCoreFoundationVersionNumber >= 1450.14)];
+    [self.RestoreRootFSSwitch setEnabled:(kCFCoreFoundationVersionNumber >= 1452.23)];
     [self.tableView reloadData];
 }
 

--- a/Undecimus/ViewController.m
+++ b/Undecimus/ViewController.m
@@ -2308,7 +2308,7 @@ void exploit(mach_port_t tfp0,
         if (![SettingsTableViewController isSupported]) {
             PROGRESS("Unsupported", 0, 1);
         }
-        if ((((!access("/electra", F_OK) && !(is_symlink("/electra") == 1)))) && kCFCoreFoundationVersionNumber < 1450.14) {
+        if ((((!access("/electra", F_OK) && !(is_symlink("/electra") == 1)))) && kCFCoreFoundationVersionNumber < 1452.23) {
             NOTICE("Other jailbreak detected. Please manually uninstall it and try this again.", 1, 1);
             exit(1);
         }


### PR DESCRIPTION
Some signing services don't use embedded.mobileprovision, this is a better way to check if you can use mptcp sockets. socket(39, 1, 0) will return -1 in case of error