### PR TITLE
Fix host priv & don't run jailbreakd on substrate

### DIFF
--- a/Undecimus/source/ViewController.m
+++ b/Undecimus/source/ViewController.m
@@ -2320,8 +2320,6 @@ void exploit(mach_port_t tfp0,
         }
         [resources addObject:@(amfid_payload)];
         [resources addObject:@"/bin/launchctl"];
-        //[resources addObject:@"/etc/rc.d/substrate"];
-        //[resources addObject:@"/usr/libexec/substrated"];
         
         const char *resarray[resources.count + 1];
         for (int i=0; i<resources.count; i++) {

--- a/Undecimus/source/ViewController.m
+++ b/Undecimus/source/ViewController.m
@@ -2319,8 +2319,7 @@ void exploit(mach_port_t tfp0,
             [resources addObjectsFromArray:[NSArray arrayWithContentsOfFile:@"/usr/share/undecimus/injectme.plist"]];
         }
         [resources addObject:@(amfid_payload)];
-        [resources addObject:@"/bin/launchctl"];
-        
+
         const char *resarray[resources.count + 1];
         for (int i=0; i<resources.count; i++) {
             resarray[i] = [resources[i] UTF8String];


### PR DESCRIPTION
Getting kernel creds will give you a different host port and patching that will mess up host_get_special_port() for root users (strangely it starts working for mobile users?). Also fix a bad logic which would cause jailbreakd to spawn even with substrate.