### PR TITLE
fix iPad Pro 10.5 on iOS 12

### DIFF
--- a/Undecimus/source/kernel_alloc.c
+++ b/Undecimus/source/kernel_alloc.c
@@ -3,7 +3,7 @@
  * Brandon Azad
  */
 #include "kernel_alloc.h"
-
+#include <CoreFoundation/CoreFoundation.h>
 #include <assert.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -356,7 +356,7 @@ ool_ports_spray_size_with_gc(mach_port_t *holding_ports, size_t *holding_port_co
 	for (; ports_used < port_count && ools_left > 0; ports_used++) {
 		// Spray this port one message at a time until we've maxed out its queue.
 		size_t messages_sent = 0;
-		for (; messages_sent < MACH_PORT_QLIMIT_DEFAULT && ools_left > 0; messages_sent++) {
+		for (; messages_sent < (kCFCoreFoundationVersionNumber >= 1535.12 ? MACH_PORT_QLIMIT_MAX : MACH_PORT_QLIMIT_DEFAULT) && ools_left > 0; messages_sent++) {
 			// If we've crossed the GC sleep boundary, sleep for a bit and schedule the
 			// next one.
 			if (sprayed >= next_gc_step) {

--- a/Undecimus/source/voucher_swap.c
+++ b/Undecimus/source/voucher_swap.c
@@ -881,7 +881,7 @@ voucher_swap() {
 	// kalloc.32768 zone. We need to do this slowly in order to force a zone garbage
 	// collection. Spraying 17% of memory (450 MB on the iPhone XR) with OOL ports should be
 	// plenty.
-    const size_t ool_ports_spray_size = (kCFCoreFoundationVersionNumber >= 1535.12 ? 0.17 : 0.085) * platform.memory_size;
+    const size_t ool_ports_spray_size = (kCFCoreFoundationVersionNumber >= 1535.12 ? 0.25 : 0.085) * platform.memory_size;
 	mach_port_t *ool_holding_ports = gc_ports + gc_port_count;
 	size_t ool_holding_port_count = 500;
 	sprayed_size = ool_ports_spray_size_with_gc(ool_holding_ports, &ool_holding_port_count,


### PR DESCRIPTION
This ups the success rate on the iPad Pro 10.5 on iOS 12.
I'm not sure if it fixes A12. I have no test devices.
It shouldn't break any devices ( I tested my iPad Pro 10.5 on iOS 11, an iPad Pro 10.5 and an iPhone X on iOS 12 from @StrugglingDoge, special thanks to him).