### PR TITLE
don't log ECID to diags

### DIFF
--- a/Undecimus/source/JailbreakViewController.m
+++ b/Undecimus/source/JailbreakViewController.m
@@ -1033,7 +1033,6 @@ void jailbreak()
         LOG("Logging ECID...");
         SETMESSAGE(NSLocalizedString(@"Failed to log ECID.", nil));
         CFStringRef value = MGCopyAnswer(kMGUniqueChipID);
-        LOG("ECID = %@", value);
         _assert(value != nil, message, true);
         _assert(modifyPlist(prefsFile, ^(id plist) {
             plist[K_ECID] = CFBridgingRelease(value);


### PR DESCRIPTION
I remember this being removed before.
When users share diagnostics, their ECID is in plain text there, when it's not needed(?).