### PR TITLE
Make post.sh work with the brew version of tar

### DIFF
--- a/post.sh
+++ b/post.sh
@@ -6,7 +6,9 @@ if [ -f ~/.profile ]; then
 fi
 
 if [[ "${CODE_SIGNING_REQUIRED}" == "NO" ]]; then
-  if which -s gnutar; then
+  if which -s gtar; then
+    TAR=gtar
+  elif which -s gnutar; then
     TAR=gnutar
   else
     TAR=tar


### PR DESCRIPTION
if you install gnu-tar from brew it installs as gtar, not gnutar. fixes this.