### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is and what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Device (please complete the following information):**
+ - iOS Version: 
+ - iOS Device: 
+ - unc0ver Version: 
+
+**Place an "x" between the brackets if true:**
+ - [ ] this is a bug others will be able to reproduce
+ - [ ] this issue is present with all tweaks uninstalled(except for default packages) or disabled
+ - [ ] this issue is present after a rootfs restore
+ - [ ] this issue is present on the latest version of unc0ver

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,3 +30,6 @@ If applicable, add screenshots to help explain your problem.
  - [ ] this issue is present with all tweaks uninstalled(except for default packages) or disabled
  - [ ] this issue is present after a rootfs restore
  - [ ] this issue is present on the latest version of unc0ver
+
+**Logs**
+If applicable, add logs or error messages here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Due to the large number of new issues with very little information or issues unrelated to unc0ver itself, I added Github issue templates to make this easier to manage.

You can see how these issue templates would look like if merged [here](https://github.com/airsquared/Undecimus/issues/new/choose).

Closes #613.

This PR also partially helps adhere to the [recommended community standards](https://github.com/pwn20wndstuff/Undecimus/community).