### PR TITLE
Allow mach_swap on 6s/SE

### DIFF
--- a/Undecimus/source/utils.m
+++ b/Undecimus/source/utils.m
@@ -1121,7 +1121,7 @@ bool supportsExploit(exploit_t exploit) {
             break;
         }
         case mach_swap_exploit: {
-            if (vm_kernel_page_size != 0x1000 && !machineNameContains("iPad5,")) {
+            if (vm_kernel_page_size != 0x1000 && !machineNameContains("iPad5,") && !machineNameContains("iPhone8,")) {
                 return false;
             }
             if (get_machswap_offsets() == NULL) {


### PR DESCRIPTION
Updates utils.m to enable mach_swap on iPhone8,x (6S [Plus] & SE)